### PR TITLE
Pvchandler fix

### DIFF
--- a/pkg/handlers/pvchandler.go
+++ b/pkg/handlers/pvchandler.go
@@ -1,24 +1,26 @@
 package handlers
 
 import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"math/rand"
 	"os"
 	"os/exec"
-	"log"
-	"strings"
-	"strconv"
-	"fmt"
-	"time"
-	"reflect"
 	"path/filepath"
-	"io/ioutil"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/nokia/dynamic-local-pv-provisioner/pkg/k8sclient"
 
+	syscall "golang.org/x/sys/unix"
 	"k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/rest"
-	syscall "golang.org/x/sys/unix"
+	"k8s.io/client-go/tools/cache"
 )
 
 const (
@@ -48,7 +50,9 @@ func (pvcHandler *PvcHandler) CreateController() cache.Controller {
 	kubeInformerFactory := informers.NewSharedInformerFactory(pvcHandler.k8sClient, time.Second*30)
 	controller := kubeInformerFactory.Core().V1().PersistentVolumeClaims().Informer()
 	controller.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { pvcHandler.pvcAdded(*(reflect.ValueOf(obj).Interface().(*v1.PersistentVolumeClaim))) },
+		AddFunc: func(obj interface{}) {
+			pvcHandler.pvcAdded(*(reflect.ValueOf(obj).Interface().(*v1.PersistentVolumeClaim)))
+		},
 		DeleteFunc: func(obj interface{}) {},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			pvcHandler.pvcChanged(*(reflect.ValueOf(oldObj).Interface().(*v1.PersistentVolumeClaim)), *(reflect.ValueOf(newObj).Interface().(*v1.PersistentVolumeClaim)))
@@ -59,7 +63,7 @@ func (pvcHandler *PvcHandler) CreateController() cache.Controller {
 
 func (pvcHandler *PvcHandler) pvcAdded(pvc v1.PersistentVolumeClaim) {
 	log.Printf("DEBUG: PVC Added: %+v\n", pvc)
-	handlePvc, pvDirPath := shouldPvcBeHandled(pvc, pvcHandler.nodeName, pvcHandler.storagePath)
+	handlePvc, pvDirPath := shouldPvcBeHandled(v1.PersistentVolumeClaim{}, pvc, pvcHandler.nodeName, pvcHandler.storagePath)
 	if !handlePvc {
 		log.Println("DEBUG: pvcAdded - Not my job...")
 		return
@@ -72,7 +76,7 @@ func (pvcHandler *PvcHandler) pvcAdded(pvc v1.PersistentVolumeClaim) {
 
 func (pvcHandler *PvcHandler) pvcChanged(oldPvc v1.PersistentVolumeClaim, newPvc v1.PersistentVolumeClaim) {
 	log.Printf("PVC changed: %+v\n", newPvc)
-	handlePvc, pvDirPath := shouldPvcBeHandled(newPvc, pvcHandler.nodeName, pvcHandler.storagePath)
+	handlePvc, pvDirPath := shouldPvcBeHandled(oldPvc, newPvc, pvcHandler.nodeName, pvcHandler.storagePath)
 	if !handlePvc {
 		log.Println("DEBUG: pvcChanged - Not my job...")
 		return
@@ -98,14 +102,16 @@ func (pvcHandler *PvcHandler) enoughLvCapacity(pvc v1.PersistentVolumeClaim) boo
 	return true
 }
 
-func shouldPvcBeHandled(pvc v1.PersistentVolumeClaim, nodeName string, storagePath string) (bool, string) {
-	if pvc.Status.Phase == v1.ClaimPending {
-		if pvcNodeName, ok := pvc.ObjectMeta.Annotations[k8sclient.NodeName]; ok && (pvcNodeName == nodeName) {
-			pvDir := storagePath + "/" + pvc.ObjectMeta.Namespace + "_" + pvc.ObjectMeta.Name
-			if _, err := os.Stat(pvDir); os.IsNotExist(err) {
-				return true, pvDir
+func shouldPvcBeHandled(oldPvc v1.PersistentVolumeClaim, newPvc v1.PersistentVolumeClaim, nodeName string, storagePath string) (bool, string) {
+	if newPvc.Status.Phase == v1.ClaimPending {
+		if pvcNodeName, ok := newPvc.ObjectMeta.Annotations[k8sclient.NodeName]; ok && (pvcNodeName == nodeName) {
+			if isChangeEnoughToProceed(oldPvc, newPvc) {
+				pvDir := storagePath + "/" + newPvc.ObjectMeta.Namespace + "_" + newPvc.ObjectMeta.Name + "-" + generateRandomSuffix(8)
+				if _, err := os.Stat(pvDir); os.IsNotExist(err) {
+					return true, pvDir
+				}
+				log.Println("DEBUG: " + pvDir + " already exists!")
 			}
-			log.Println("DEBUG: " + pvDir + " already exists!")
 		} else {
 			log.Printf("DEBUG: Nodename: %t, %s, env: %s\n", ok, pvcNodeName, nodeName)
 		}
@@ -133,9 +139,9 @@ func (pvcHandler *PvcHandler) createPVStorage(pvc v1.PersistentVolumeClaim, pvDi
 		return
 	}
 	if string(projectsContent) != "" {
-		lines := strings.Split(string(projectsContent),"\n")
+		lines := strings.Split(string(projectsContent), "\n")
 		projid, err := strconv.Atoi(strings.Split(lines[len(lines)-2], ":")[0])
-		if err != nil{
+		if err != nil {
 			log.Println("ERROR: Cannot convert project id from " + lines[len(lines)-2] + " because: " + err.Error())
 			return
 		}
@@ -155,7 +161,7 @@ func (pvcHandler *PvcHandler) createPVStorage(pvc v1.PersistentVolumeClaim, pvDi
 	}
 	defer projFile.Close()
 	project := fmt.Sprintf("%d:%s\n", projID, pvDirPath)
-	_,err = projFile.WriteString(project)
+	_, err = projFile.WriteString(project)
 	if err != nil {
 		log.Println("ERROR: Cannot modify /etc/projects file, because: " + err.Error())
 		return
@@ -168,7 +174,7 @@ func (pvcHandler *PvcHandler) createPVStorage(pvc v1.PersistentVolumeClaim, pvDi
 	defer projIdFile.Close()
 	projName := filepath.Base(pvDirPath)
 	projid := fmt.Sprintf("%s:%d\n", projName, projID)
-	_,err = projIdFile.WriteString(projid)
+	_, err = projIdFile.WriteString(projid)
 	if err != nil {
 		log.Println("ERROR: Cannot modify /etc/projid file, because: " + err.Error())
 		return
@@ -203,15 +209,40 @@ func (pvcHandler *PvcHandler) createPVStorage(pvc v1.PersistentVolumeClaim, pvDi
 	// Set fstab file
 	file, err := os.OpenFile(fstabPath, os.O_APPEND|os.O_WRONLY|os.O_SYNC, 0755)
 	if err != nil {
-		log.Println("ERROR: Cannot open fstab file: " + fstabPath + " because: " + err.Error()+ "\nCannot save mountpoint!")
+		log.Println("ERROR: Cannot open fstab file: " + fstabPath + " because: " + err.Error() + "\nCannot save mountpoint!")
 		return
 	}
 	defer file.Close()
 	bindMountCommand := fmt.Sprintf("%[1]s %[1]s none bind 0 0\n", pvDirPath)
-	_,err = file.WriteString(bindMountCommand)
+	_, err = file.WriteString(bindMountCommand)
 	if err != nil {
-		log.Println("ERROR: Cannot modify fstab file: " + fstabPath + " because: " + err.Error()+ "\nCannot save mountpoint!")
+		log.Println("ERROR: Cannot modify fstab file: " + fstabPath + " because: " + err.Error() + "\nCannot save mountpoint!")
 		return
 	}
-	log.Println("DEBUG: createPVStorage executor successfull!")
+	log.Println("DEBUG: createPVStorage executor successful!")
+}
+
+func generateRandomSuffix(suffixlength int) string {
+	charPool := []byte("abcdefghijklmnopqrstuvwxyz1234567890")
+	rand.Seed(time.Now().Unix())
+	bytes := make([]byte, suffixlength)
+	for i := range bytes {
+		bytes[i] = charPool[rand.Intn(len(charPool))]
+	}
+	return string(bytes)
+}
+
+func isChangeEnoughToProceed(oldPvc v1.PersistentVolumeClaim, newPvc v1.PersistentVolumeClaim) bool {
+	old_nodename := oldPvc.ObjectMeta.Annotations[k8sclient.NodeName]
+	new_nodename := newPvc.ObjectMeta.Annotations[k8sclient.NodeName]
+	if !reflect.DeepEqual(oldPvc, v1.PersistentVolumeClaim{}) {
+		if old_nodename != new_nodename && old_nodename == "" {
+			return true
+		}
+	} else { // in case the created PVC already has the "nokia.k8s.io/nodeName" annotation otherwise set by provisioner
+		if new_nodename != "" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
After pvc deletion, pvc recreation fails since pv mount dir already exists
Proposed fix:
  Append a generated 8-character-long randomized string to the pv folder to be created